### PR TITLE
vendor: fix ro.adb.secure for vendor-building devices

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -28,7 +28,7 @@ endif
 
 ifneq ($(TARGET_BUILD_VARIANT),eng)
 # Enable ADB authentication
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.adb.secure=1
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.adb.secure=1
 endif
 
 ifeq ($(BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE),)


### PR DESCRIPTION
* This ensures the prop is set correctly for devices
  that build a vendor image by placing the prop in
  /system/etc/prop.default, rather than /vendor/default.prop
  so it'll be in a prop file that is run for mangle_default_prop
  in build/make/tools/post_process_props.py, therby
  setting persist.sys.usb.config correctly to "none".

Change-Id: I4027541cf1eae9dd967636efe35de9578922b725